### PR TITLE
release: 0.6.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0-alpha.9] - Unreleased
+## [0.6.0] - 2026-07-04
 
 Pre-1.0 API and architecture cleanup pass: closes gaps found in a full crate review and
 comparison against `glam`, `euclid`, `vek`, and `bracket-lib`. All changes are breaking.
@@ -50,6 +50,17 @@ comparison against `glam`, `euclid`, `vek`, and `bracket-lib`. All changes are b
 ### Removed
 
 - `TryFromPos` / `TryIntoPos` traits — use `Pos::try_cast::<U>()` instead
+
+### Chores (pre-stable pass)
+
+- `missing_docs`, `unreachable_pub`, and `unused_qualifications` lints promoted from `warn` to
+  `deny`, and `unsafe_code = "forbid"` added to `[lints.rust]` for parity with the `#![forbid]`
+  attribute already in `lib.rs` and with sibling crates' `Cargo.toml` lint configuration.
+- `just semver-checks` no longer hardcodes a stale baseline version (previously `0.5.7`); lets
+  `cargo-semver-checks` auto-select the latest published release, matching the fix already applied
+  in `grixy`.
+- Documented the unsigned-underflow panic behavior of `Rect::inflate()`/`Rect::shrink()` when the
+  deltas exceed the rectangle's existing position/size.
 
 ## [0.6.0-alpha.8] - 2026-06-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "ixy"
-version = "0.6.0-alpha.9"
+version = "0.6.0"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,16 +7,17 @@ description = "A minimal, no-std compatible crate for 2D integer geometry"
 repository = "https://github.com/crates-lurey-io/ixy"
 homepage = "https://github.com/crates-lurey-io/ixy"
 documentation = "https://docs.rs/ixy"
-version = "0.6.0-alpha.9"
+version = "0.6.0"
 rust-version = "1.87"
 authors = ["Matan Lurey <matan@lurey.org>"]
 keywords = ["2d", "geometry", "integer", "grid", "position"]
 categories = ["game-development", "mathematics", "no-std"]
 
 [lints.rust]
-missing_docs = "warn"
-unreachable_pub = "warn"
-unused_qualifications = "warn"
+unsafe_code = "forbid"
+missing_docs = "deny"
+unreachable_pub = "deny"
+unused_qualifications = "deny"
 
 [lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/Justfile
+++ b/Justfile
@@ -32,7 +32,11 @@ doc:
     cargo doc --all-features --no-deps --open --lib
 
 semver-checks:
-    cargo tool cargo-semver-checks --baseline-version 0.5.7
+    # No --baseline-version pin: a hardcoded prerelease baseline goes stale on every alpha bump
+    # and, worse, can silently re-resolve a loose dependency requirement in the baseline against a
+    # newer breaking prerelease (see grixy's alpha.8 CHANGELOG). Letting cargo-semver-checks
+    # auto-select the baseline compares against the latest published release instead.
+    cargo tool cargo-semver-checks
 
 msrv:
     cargo tool cargo-hack check --rust-version --workspace --all-targets --ignore-private

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -544,6 +544,9 @@ impl<T: Int> Rect<T> {
     /// Returns a rectangle grown by `dx` on the left/right edges and `dy` on the top/bottom
     /// edges.
     ///
+    /// For an unsigned `T`, this panics in debug builds (wraps in release) if `dx`/`dy` exceed
+    /// this rectangle's `x`/`y`, since the left/top edge would need to move below zero.
+    ///
     /// ## Examples
     ///
     /// ```rust
@@ -564,6 +567,9 @@ impl<T: Int> Rect<T> {
 
     /// Returns a rectangle shrunk by `dx` on the left/right edges and `dy` on the top/bottom
     /// edges.
+    ///
+    /// For an unsigned `T`, this panics in debug builds (wraps in release) if `dx + dx`/`dy + dy`
+    /// exceed this rectangle's `w`/`h`.
     ///
     /// ## Examples
     ///


### PR DESCRIPTION
Promotes ixy to a stable-but-pre-1.0 `0.6.0` release. No API breaking changes beyond what alpha.9 already shipped (`Size`/`HasSize` generic over `Int`, `Rect` ctor uniformity, `layout::Traversal`->`Layout`/`Linear`->`LinearLayout` renames, `#[must_use]` additions).

## Changes

- **Lint config**: promote `missing_docs`/`unreachable_pub`/`unused_qualifications` from `warn` to `deny`, and add `unsafe_code = "forbid"` to `[lints.rust]` for parity with the `#![forbid(unsafe_code)]` attribute already in `lib.rs` and with sibling crates' `Cargo.toml` lint configuration.
- `just semver-checks` no longer hardcodes a stale baseline version (previously `0.5.7`, several majors behind); lets `cargo-semver-checks` auto-select the latest published release, matching the fix already applied in `grixy`.
- Documented the unsigned-underflow panic behavior of `Rect::inflate()`/`Rect::shrink()` when the deltas exceed the rectangle's existing position/size.
- Version bump to `0.6.0`, CHANGELOG entry.

## Downstream coordination

`grixy` exact-pins `ixy = "=0.6.0-alpha.9"` and `hexal` loosely requires `ixy = "0.6.0-alpha.7"` (already silently resolved to alpha.9/alpha.8 in their lockfiles - the exact drift hazard grixy's own alpha.8 CHANGELOG called out). Both need a follow-up bump to this stable `0.6.0` once it's published; tracked in their own release PRs (opened alongside this one).

Full readiness review: `.matan/next.md` in this repo (gitignored, not part of this diff).

Verified: `cargo build/clippy/fmt/test/doc --all-features` all clean.
